### PR TITLE
Adds aria-labelledby and aria-label for Password Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,12 @@
     "start": "NODE_ENV=production PORT=8080 node ./dist/server.js"
   },
   "devDependencies": {
+    "eslint": "^5.7.0",
+    "eslint-plugin-jsx-a11y": "^6.1.2",
     "lerna": "^3.4.3",
     "rimraf": "^2.6.2"
+  },
+  "dependencies": {
+    "react-a11y": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,5 @@
   "devDependencies": {
     "lerna": "^3.4.3",
     "rimraf": "^2.6.2"
-  },
-  "dependencies": {
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,12 +17,9 @@
     "start": "NODE_ENV=production PORT=8080 node ./dist/server.js"
   },
   "devDependencies": {
-    "eslint": "^5.7.0",
-    "eslint-plugin-jsx-a11y": "^6.1.2",
     "lerna": "^3.4.3",
     "rimraf": "^2.6.2"
   },
   "dependencies": {
-    "react-a11y": "^1.0.1"
   }
 }

--- a/source/client/application/advanced/advanced.form.items.component.js
+++ b/source/client/application/advanced/advanced.form.items.component.js
@@ -43,7 +43,7 @@ export class AdvancedFormItemsComponent extends React.Component {
         return (
             <div>
                 Length: { settings.length }
-                <Slider value={ settings.length } onChange={ this.changeLength } min={ 5 } max={ 100 } step={ 1 } sliderStyle={ sliderStyle }/>
+                <Slider value={ settings.length } onChange={ this.changeLength } aria-labelledby={ "Password Length: " + settings.length + ". Increase or decrease length using arrow keys."} min={ 5 } max={ 100 } step={ 1 } sliderStyle={ sliderStyle }/>
                 {
                     this.toggleList.map((toggle) => {
                         return (
@@ -56,6 +56,7 @@ export class AdvancedFormItemsComponent extends React.Component {
                                     defaultToggled={ toggle.defaultToggled }
                                     style={ toggleStyle }
                                     onToggle={ this.changeToggle }
+                                    aria-label={ toggle.label }
                                 />
                             </div>
                         )

--- a/source/client/application/advanced/advanced.form.items.component.js
+++ b/source/client/application/advanced/advanced.form.items.component.js
@@ -43,7 +43,7 @@ export class AdvancedFormItemsComponent extends React.Component {
         return (
             <div>
                 Length: { settings.length }
-                <Slider value={ settings.length } onChange={ this.changeLength } aria-labelledby={ "Password Length: " + settings.length + ". Increase or decrease length using arrow keys."} min={ 5 } max={ 100 } step={ 1 } sliderStyle={ sliderStyle }/>
+                <Slider value={ settings.length } onChange={ this.changeLength } aria-labelledby={ "Password Length Slider: " + settings.length + ". Increase or decrease length using arrow keys."} min={ 5 } max={ 100 } step={ 1 } sliderStyle={ sliderStyle }/>
                 {
                     this.toggleList.map((toggle) => {
                         return (

--- a/source/client/application/advanced/advanced.form.items.component.js
+++ b/source/client/application/advanced/advanced.form.items.component.js
@@ -56,7 +56,7 @@ export class AdvancedFormItemsComponent extends React.Component {
                                     defaultToggled={ toggle.defaultToggled }
                                     style={ toggleStyle }
                                     onToggle={ this.changeToggle }
-                                    aria-labelledby={ toggle.label }
+                                    aria-label={ toggle.label }
                                 />
                             </div>
                         )

--- a/source/client/application/advanced/advanced.form.items.component.js
+++ b/source/client/application/advanced/advanced.form.items.component.js
@@ -43,7 +43,7 @@ export class AdvancedFormItemsComponent extends React.Component {
         return (
             <div>
                 Length: { settings.length }
-                <Slider value={ settings.length } onChange={ this.changeLength } aria-labelledby={ "Password Length Slider: " + settings.length + ". Increase or decrease length using arrow keys."} min={ 5 } max={ 100 } step={ 1 } sliderStyle={ sliderStyle }/>
+                <Slider value={ settings.length } onChange={ this.changeLength } aria-label={ "Password Length Slider: " + settings.length + ". Increase or decrease length using arrow keys."} min={ 5 } max={ 100 } step={ 1 } sliderStyle={ sliderStyle }/>
                 {
                     this.toggleList.map((toggle) => {
                         return (
@@ -56,7 +56,7 @@ export class AdvancedFormItemsComponent extends React.Component {
                                     defaultToggled={ toggle.defaultToggled }
                                     style={ toggleStyle }
                                     onToggle={ this.changeToggle }
-                                    aria-label={ toggle.label }
+                                    aria-labelledby={ toggle.label }
                                 />
                             </div>
                         )


### PR DESCRIPTION
This resolves part of the issue #32 where macOS VoiceOver would not read aloud any labels of the checkboxes. ChromeVox continues to not read the labels. 